### PR TITLE
Fixing Sorting with Search

### DIFF
--- a/app/controllers/establishments_controller.rb
+++ b/app/controllers/establishments_controller.rb
@@ -5,13 +5,18 @@ class EstablishmentsController < ApplicationController
     @establishments = Establishment.page(params[:page]).per(30).includes(:inspections => :establishment)
 
     if params[:search]
-      @establishments = Establishment.search(params[:search]).page(params[:page]).per(30).includes(:inspections => :establishment)
+      session[:search] = params[:search]
     end
 
     if (params[:sort] && params[:direction])
-      @establishments.order(params[:sort] + ' ' + params[:direction])
+      session[:sort] = params[:sort]
+      session[:direction] = params[:direction]
+    end
+
+    if session[:search].present?
+      @establishments = Establishment.search(session[:search]).page(params[:page]).per(30).includes(:inspections => :establishment).order(session[:sort] + ' ' + session[:direction])
     else
-      @establishments.order(:name)
+      @establishments = Establishment.page(session[:page]).per(30).includes(:inspections => :establishment).order(session[:sort] + ' ' + session[:direction])
     end
   end
 

--- a/app/models/establishment.rb
+++ b/app/models/establishment.rb
@@ -8,6 +8,6 @@ class Establishment < ApplicationRecord
   end
 
   def self.search(search)
-    where("name ILIKE ?", "%#{sanitize_sql_like(search)}%") 
+    where("establishments.name ILIKE ?", "%#{sanitize_sql_like(search)}%") 
   end
 end


### PR DESCRIPTION
Using `session` to save search data while performing sorts, and vice versa. Might be a temporary fix, but will need to sort out the issues with sorting by inspection date causing the number of places to jump.